### PR TITLE
translator credit, and non-breaking spaces for author names

### DIFF
--- a/publication_latex/seismica.cls
+++ b/publication_latex/seismica.cls
@@ -216,6 +216,8 @@ hyperfootnotes=false]{hyperref}
 \handedname{}
 \def\copyedname#1{\def\@copyedname{#1}}
 \copyedname{}
+\def\translatorname#1{\def\@translatorname{#1}}
+\translatorname{}
 \def\suppmat#1{\def\@suppmat{#1}}
 \suppmat{}
 
@@ -242,7 +244,8 @@ hyperfootnotes=false]{hyperref}
 \newcommand{\more@metadata}{%
 	\printifnotempty{Production Editor}{\\}{\@prodedname}{\\}
 	\printifnotempty{Handling Editor}{\\}{\@handedname}{\\}
-	\printifnotempty{Copy \& Layout Editor}{\\}{\@copyedname}{\par}
+	\printifnotempty{Copy \& Layout Editor}{\\}{\@copyedname}{\\}
+	\printifnotempty{Translator}{\\}{\@translatorname}{\par}
 	\printifnotempty{Received}{\\}{\@receiveddate}{\\}
 	\printifnotempty{Accepted}{\\}{\@accepteddate}{\\}
 	\printifnotempty{Published}{\\}{\@publisheddate}{\par}

--- a/publication_latex/seismica_template.tex
+++ b/publication_latex/seismica_template.tex
@@ -38,6 +38,7 @@
 \prodedname{Efirstname Editorname}  %% Production editor
 \handedname{Efirstname Editorname}  %% handling editor
 \copyedname{Cfirstname Copyedname}  %% copyed editor
+%\translatorname{translator name, if there is one}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Metadata by authors (Replace everything below)
@@ -45,12 +46,13 @@
 \title{A template for Seismica}
 \shorttitle{A template for Seismica} % used for header
 
-\author[1]{A. Author1
+% use ~ for non-breaking spaces in authors, so names don't break across lines
+\author[1]{A.~Author1
 	\thanks{Corresponding author: bla@som.ac.edu}
 	\orcid{0000-0002-1825-0097}}
-\author[1]{B. author2 
+\author[1]{B.~author2 
 	\orcid{0000-0002-1825-097}}
-\author[2]{C. Author3
+\author[2]{C.~Author3
 	\orcid{0000-0002-1825-007}}
 \affil[1]{affil Author 1 and 2 }
 \affil[2]{affil author 3}

--- a/submission_latex/seismica_template.tex
+++ b/submission_latex/seismica_template.tex
@@ -20,14 +20,14 @@
 \shorttitle{Your short title goes here} % used for header
 
 %% Will not be printed if anonymous option ON
-\author[1]{Name Surname
+\author[1]{Name~Surname
 	\orcid{1111-1111-1111-1111}
 	\thanks{Corresponding author: firstauthor@university.edu}
 }
-\author[2]{Name Secondauthor
+\author[2]{Name~Secondauthor
 	\orcid{2222-2222-2222-2222}
 }
-\author[1,3]{Name Thirdauthor
+\author[1,3]{Name~Thirdauthor
 	\orcid{3333-3333-3333-3333}
 }
 \affil[1]{Department of Earth Sciences, A University, City, Country}


### PR DESCRIPTION
I added an option for putting translator names along with the editors on the first page, and also made some tiny edits to the template example tex files to prompt people to use ~ in author names. Probably should have been separate commits but oh well.