### PR TITLE
landscape page option

### DIFF
--- a/publication_latex/seismica.cls
+++ b/publication_latex/seismica.cls
@@ -74,6 +74,8 @@ hyperfootnotes=false]{hyperref}
 \RequirePackage{titling}
 \RequirePackage{abstract}
 \RequirePackage{fancyhdr}
+\RequirePackage{pdflscape}
+\RequirePackage{tikz}
 \RequirePackage{bookmark}
 \RequirePackage{caption} 
 %\RequirePackage[natbibapa,sectionbib,doi]{apacite}   ### TO DO!! Conflict with... ???
@@ -522,6 +524,7 @@ hyperfootnotes=false]{hyperref}
 \newcommand{\shorttitle}[1]{\gdef\shorttitle@internal{#1}}
 \newcommand{\insertshorttitle}{\shorttitle@internal}
 
+%% header/footer style for the all pages after page 1, portrait
 \pagestyle{fancy}
 \fancyhf{}
 \fancyfoot{}
@@ -531,12 +534,38 @@ hyperfootnotes=false]{hyperref}
 %\fancyhead[R]{\footnotesize \@author[1]}
 \renewcommand{\headrule}{}
 
+%% same style (portait, pages 2+) as a fancypage for resets after landscape pages
+\fancypagestyle{plainReset}{%
+    \fancyhf{}
+    \fancyfoot{}
+    \fancyfoot[L]{\sff\bfseries\footnotesize \thepage}
+    \fancyfoot[R]{\sflight \footnotesize {\scshape \bfseries \color{seismicacolor1light} SEISMICA}~|~volume \@thevolume.\@thenumber~|~\@theyear}
+    \fancyhead[L]{\sflight \footnotesize {\scshape \bfseries \color{seismicacolor1light} SEISMICA} | {\scshape \bfseries \articletype} | \insertshorttitle}
+    %\fancyhead[R]{\footnotesize \@author[1]}
+    \renewcommand{\headrule}{}
+}
+
+%% style for first page header/footer, with ISSN
 \fancypagestyle{plain}{%
 	\fancyhead{}
 	\renewcommand{\headrule}{}
 	\fancyfoot{}
 	\fancyfoot[L]{\sff\bfseries\footnotesize \thepage}
 	\fancyfoot[R]{\sflight \footnotesize {\scshape \bfseries \color{seismicacolor1light} SEISMICA}~|~ISSN 2816-9387~|~volume \@thevolume.\@thenumber~|~\@theyear}
+}
+
+%% style for landscape page header/footer
+\fancypagestyle{lscapedplain}{%
+  \fancyhf{}
+  \fancyfoot{%
+    \begin{tikzpicture}[remember picture,overlay]
+      \node[text width=5cm,align=flush right,rotate=90] at ([xshift=-1cm,yshift=11cm]current page.east) {\sflight \footnotesize {\scshape \bfseries \color{seismicacolor1light} SEISMICA}~|~volume \@thevolume.\@thenumber~|~\@theyear};
+      \node[text width=3cm,align=flush left,rotate=90] at ([xshift=-1cm,yshift=-11.8cm]current page.east) {\sff\bfseries\footnotesize \thepage};
+    \end{tikzpicture}}
+  \fancyhead{%
+    \begin{tikzpicture}[remember picture,overlay]
+      \node[text width=20cm, align=flush left,rotate=90] at ([xshift=1cm,yshift=-3.35cm]current page.west) {\sflight \footnotesize {\scshape \bfseries \color{seismicacolor1light} SEISMICA} | {\scshape \bfseries \articletype} | \insertshorttitle};
+    \end{tikzpicture}}
 }
 
 %

--- a/publication_latex/seismica_template.tex
+++ b/publication_latex/seismica_template.tex
@@ -155,6 +155,28 @@ for mdl in mdls:
 	var = mdl.get_variance()
 \end{lstlisting}
 
+\section{Page formatting}
+If you need to add a landscape-format page, for a table or figure, there are header/footer styles in the template. Adding a landscape page will mess with tex's page-filling algorithm since it will insert the rotated page exactly where it appears in the text, so you will need to manually move text before/after to maximize page fill.
+
+%% add these lines (uncommented) before the landscape content
+%\onecolumn
+%\thispagestyle{lscapedplain}
+%\pagestyle{lscapedplain}
+%\begin{landscape}
+
+%% [add your landscape content here - if a figure*, use height=\textwidth (or .9\textwidth) instead of width to set size.
+
+%% add these lines (uncommented) after the landscape content to reset to portrait mode
+%\end{landscape}
+%\restoregeometry
+%\thispagestyle{plainReset}
+%\pagestyle{plainReset}
+
+% If you want a caption for a full-page landscape figure to be on the next page but still have the same number, you can use
+%\addcounter{figure}{-1}
+% before adding another figure environment with just the caption following the landscape page. Note that this will not play well with the XML conversion.
+
+
 \begin{acknowledgements}
 	Thank all relevant parties and acknowledge funding sources, if any.
 \end{acknowledgements}


### PR DESCRIPTION
added header/footer style for including landscape page(s) in a pdf, and some instructions in the example template tex file for how to use them.