### PR TITLE
add an option for formatting supplementary material

### DIFF
--- a/submission_latex/seismica.cls
+++ b/submission_latex/seismica.cls
@@ -36,13 +36,20 @@
 \@reportfalse
 \DeclareOption{report}{\@reporttrue}
 
+\newif\if@supplement
+\@supplementfalse
+\DeclareOption{supplement}{\@supplementtrue}
+
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
 \ProcessOptions\relax
 
 % Review option by default
 \if@preprint
 \else
+\if@supplement
+\else
 \@reviewtrue
+\fi
 \fi
 
 \if@review
@@ -273,8 +280,13 @@ hyperfootnotes=false]{hyperref}
 {\vspace*{-1.6cm} \hspace{0.1cm} 
 	\href{https://seismica.org/}{\color{black} \sffamily\small Non-peer reviewed {\bfseries\manustype} submitted to} }
 \else
+\if@supplement
+{\vspace*{-1.3cm} \hspace{0.1cm} 
+	\href{https://seismica.org/}{\color{black} \sffamily\small Supplementary material for a {\bfseries\manustype} in} }
+\else
 {\vspace*{-1.3cm} \hspace{0.1cm} 
 	\href{https://seismica.org/}{\color{black} \sffamily\small Non-peer reviewed {\bfseries\manustype} submitted to} }
+\fi
 \fi
 \vspace*{1.7cm}
 }
@@ -371,6 +383,10 @@ hyperfootnotes=false]{hyperref}
 \excludecomment{acknowledgements}
 \fi
 
+\if@supplement
+\renewcommand{\thesection}{S\arabic{section}}
+\fi
+
 %-------------------------------------------------------------------------------
 %                Configuration for header and footer
 %-------------------------------------------------------------------------------
@@ -400,7 +416,11 @@ hyperfootnotes=false]{hyperref}
 \fancyhf{}
 \fancyfoot{}
 \fancyfoot[L]{\sffamily\bfseries\footnotesize \thepage}
+\if@supplement
+\fancyhead[L]{\sffamily\footnotesize This is supplementary material for a {\bfseries\manustype} in {\scshape \bfseries\href{https://seismica.org/}{\color{seismicacolor1}SEISMICA}} }
+\else
 \fancyhead[L]{\sffamily\footnotesize This is a non-peer reviewed {\bfseries\manustype} submitted to {\scshape \bfseries\href{https://seismica.org/}{\color{seismicacolor1}SEISMICA}} }
+\fi
 \fancyhead[R]{\sffamily\footnotesize \color{seismicacolor1}\insertshorttitle}
 \renewcommand{\headrule}{}
 
@@ -434,6 +454,12 @@ singlelinecheck=false, oneside}
 \fi
 
 \renewcommand{\theequation}{\color{gray}\arabic{equation}}
+
+% supplemental figures and tables
+\if@supplement
+\renewcommand{\thefigure}{S\arabic{figure}}
+\renewcommand{\thetable}{S\arabic{table}}
+\fi
 
 %%-------------------------------------------------------------------------------
 %%                Configuration for references

--- a/submission_latex/seismica_template.tex
+++ b/submission_latex/seismica_template.tex
@@ -8,12 +8,14 @@
 %%					languages
 %%					preprint
 %%					report
+%%                                      supplement
 
 %% anonymous: produces an anonymous PDF for double-blind review. Will NOT print authors information and acknowledgements, but WILL PRINT data availibility section, so be careful!
 %% breakmath: for manuscripts with many long formulas, you can specify the breakmath option (loads the package breqn and uses the dmath environment)
 %% languages: see below, use to add abstract(s) in additional languages
 %% preprint: removes line numbers, switch to two-columns
 %% report: if this is a report
+%% supplement: for supplements - no line numbers, two-column, and numbering is S1, S2, etc.
 
 %\documentclass[breakmath,report]{seismica}
 \documentclass[]{seismica}
@@ -96,11 +98,15 @@
 %%		many abstracts, you can use the command \addsummaries. It will induce a pagebreak.
 
 \begin{document}
+
+%% if this is a supplement and includes code, uncomment the next line:
+%\renewcommand{\thelstlisting}{S\arabic{lstlisting}}
 	
 	%% Your article can include up to 3 abstracts. The first is the English language abstract.
 	%% For other languages in the second and third optional abstracts, you might have to define 
 	%%      additional font(s) in preamble above
 	%% You can also include a non-technical summary in addition to the abstract(s)
+        %% For supplements, you can use \makeseistitle{} without any summaries/abstracts in it.
 	\makeseistitle{
 		\begin{summary}{Abstract}
 			The text for the first abstract goes here. This should be in English, no longer than 200 words, and should not include references.


### PR DESCRIPTION
Adds an option which changes the page headings and numbering schemes if someone wants to use a template to make their supplement look nice.