### PR TITLE
bst cleanup

### DIFF
--- a/publication_latex/abbrvnat_seismica_upcasetitle.bst
+++ b/publication_latex/abbrvnat_seismica_upcasetitle.bst
@@ -1,8 +1,7 @@
-%% File: `abbrvnat.bst' last updated - 2023-07-15
+%% File: `abbrvnat.bst' last updated - 2025-04-03
 %% A modification of `abbrv.bst' for use with natbib package
 %%
 %% modified for Seismica
-%% last updated 2025-03-31 hfmark
 %%
 %% Copyright 1993-2007 Patrick W Daly
 %% Max-Planck-Institut f\"ur Sonnensystemforschung
@@ -288,10 +287,82 @@ FUNCTION {format.url}
   if$
 }
 
+FUNCTION { strip.doi }
+{ % Borrowed from Association for Computing Machinery typesetting materials
+  %
+  % Strip any Web address prefix to recover the bare DOI, leaving the
+  % result on the output stack, as recommended by CrossRef DOI
+  % documentation.
+  % For example, reduce "http://doi.acm.org/10.1145/1534530.1534545" to
+  % "10.1145/1534530.1534545".  A suitable URL is later typeset and
+  % displayed as the LAST item in the reference list entry.  Publisher Web
+  % sites wrap this with a suitable link to a real URL to resolve the DOI,
+  % and the master https://doi.org/ address is preferred, since publisher-
+  % specific URLs can disappear in response to economic events.  All
+  % journals are encouraged by the DOI authorities to use that typeset
+  % format and link procedures for uniformity across all publications that
+  % include DOIs in reference lists.
+  % The numeric prefix is guaranteed to start with "10.", so we use
+  % that as a test.
+  % 2017-02-04 Added stripping of https:// (Boris Veytsman)
+  doi #1 #3 substring$ "10." =
+    { doi }
+    {
+      doi 't :=  % get modifiable copy of DOI
+
+      % Change https:// to http:// to strip both prefixes (BV)
+
+      t #1 #8 substring$ "https://" =
+        { "http://"  t #9 t text.length$ #8 - substring$ * 't := }
+        { }
+      if$
+
+      t #1 #7 substring$ "http://" =
+        {
+            t #8 t text.length$ #7 - substring$ 't :=
+
+            "INTERNAL STYLE-FILE ERROR" 's :=
+
+            % search for next "/" and assign its suffix to s
+
+            { t text.length$ }
+            {
+              t #1 #1 substring$ "/" =
+                {
+                  % save rest of string as true DOI (should be 10.xxxx/yyyy)
+                  t #2 t text.length$ #1 - substring$ 's :=
+                  "" 't :=    % empty string t terminates the loop
+                }
+                {
+                  % discard first character and continue loop: t <= substring(t,2,last)
+                  t #2 t text.length$ #1 - substring$ 't :=
+                }
+              if$
+            }
+            while$
+
+            % check for valid DOI (should be 10.xxxx/yyyy)
+            s #1 #3 substring$ "10." =
+              { }
+              { "unrecognized DOI substring " s * " in DOI value [" * doi * "]" * warning$ }
+            if$
+
+            s   % push the stripped DOI on the output stack
+
+        }
+        {
+          "unrecognized DOI value [" doi * "]" * warning$
+          doi   % push the unrecognized original DOI on the output stack
+        }
+      if$
+    }
+  if$
+}
+
 FUNCTION {format.doi}
 { doi empty$
     { "" }
-    { new.block "\doi{" doi * "}" * }
+    { new.block "\doi{" strip.doi * "}" * }
   if$
 }
 
@@ -301,7 +372,7 @@ FUNCTION {format.doiurl}
         { "" }
         {new.block "\url{" url * "}" * }
         if$}
-    { new.block "\doi{" doi * "}" * }
+    { new.block "\doi{" strip.doi * "}" * }
     if$
 }
 

--- a/publication_latex/abbrvnat_seismica_upcasetitle.bst
+++ b/publication_latex/abbrvnat_seismica_upcasetitle.bst
@@ -1,6 +1,9 @@
 %% File: `abbrvnat.bst' last updated - 2023-07-15
 %% A modification of `abbrv.bst' for use with natbib package
 %%
+%% modified for Seismica
+%% last updated 2025-03-31 hfmark
+%%
 %% Copyright 1993-2007 Patrick W Daly
 %% Max-Planck-Institut f\"ur Sonnensystemforschung
 %% Max-Planck-Str. 2
@@ -76,7 +79,7 @@ ENTRY
   {}
   { label extra.label sort.label short.list }
 
-INTEGERS { output.state before.all mid.sentence after.sentence after.block }
+INTEGERS { output.state before.all mid.sentence mid.string after.sentence after.block }
 
 FUNCTION {init.state.consts}
 { #0 'before.all :=
@@ -98,7 +101,11 @@ FUNCTION {output.nonnull}
         }
         { output.state before.all =
             'write$
-            { add.period$ " " * write$ }
+            { output.state mid.string =
+                { " " * write$ }
+                { add.period$ " " * write$ }
+            if$
+            }
           if$
         }
       if$
@@ -299,12 +306,10 @@ FUNCTION {format.doiurl}
 }
 
 FUNCTION {format.title}
-{ 
-%title empty$
-%    { "" }
-%    { title "t" change.case$ }
-%  if$
-title
+{ title empty$
+    { "" }
+    { title }
+if$
 }
 
 FUNCTION {format.full.names}
@@ -624,21 +629,17 @@ FUNCTION {format.thesis.type}
   if$
 }
 
-FUNCTION {format.tr.number}
-{ type empty$
-    { "Technical Report" }
-    'type
-  if$
-  number empty$
-    { "t" change.case$ }
-    { number tie.or.space.connect }
+FUNCTION {format.misc.type}
+{ type field.or.null
+  duplicate$ empty$ 'skip$
+    { mid.string 'output.state :=
+    " [" swap$  * "]" *  }
   if$
 }
 
-
-FUNCTION {format.ofr.number}
+FUNCTION {format.tr.number}
 { type empty$
-    { "Open-file Report" }
+    { "Technical Report" }
     'type
   if$
   number empty$
@@ -950,6 +951,7 @@ FUNCTION {misc}
   author format.key output
   title howpublished new.block.checkb
   format.title output
+  format.misc.type output
   howpublished new.block.checka
   howpublished output
   format.date output
@@ -1003,21 +1005,6 @@ FUNCTION {proceedings}
   fin.entry
 }
 
-FUNCTION {software}
-{ output.bibitem
-  format.authors "author" output.check
-  author format.key output
-  new.block
-  format.title "title" output.check
-  new.block
-  %format.url output
-  %format.doi output
-  format.doiurl output
-  new.block
-  note output
-  fin.entry
-}
-
 FUNCTION {techreport}
 { output.bibitem
   format.authors "author" output.check
@@ -1026,25 +1013,6 @@ FUNCTION {techreport}
   format.title "title" output.check
   new.block
   format.tr.number output.nonnull
-  institution "institution" output.check
-  address output
-  format.date "year" output.check
-  %format.url output
-  format.doiurl output
-  new.block
-  note output
-  fin.entry
-}
-
-
-FUNCTION {openfilereport}
-{ output.bibitem
-  format.authors "author" output.check
-  author format.key output
-  new.block
-  format.title "title" output.check
-  new.block
-  format.ofr.number output.nonnull
   institution "institution" output.check
   address output
   format.date "year" output.check

--- a/publication_latex/abbrvnat_seismica_upcasetitle.bst
+++ b/publication_latex/abbrvnat_seismica_upcasetitle.bst
@@ -648,6 +648,17 @@ FUNCTION {format.tr.number}
   if$
 }
 
+FUNCTION {format.preprint.number}
+{ type empty$
+    { "Unpublished" }
+    'type
+  if$
+  number empty$
+    { "t" change.case$ }
+    { number tie.or.space.connect }
+  if$
+}
+
 FUNCTION {format.article.crossref}
 { key empty$
     { journal empty$
@@ -1030,9 +1041,11 @@ FUNCTION {unpublished}
   new.block
   format.title "title" output.check
   new.block
+  format.preprint.number output.nonnull
   note "note" output.check
   format.date output
-  format.url output
+  new.block
+  format.doiurl output
   fin.entry
 }
 

--- a/publication_latex/biblio.bib
+++ b/publication_latex/biblio.bib
@@ -5,7 +5,6 @@
 	issn = {0162-1459},
 	url = {https://www.tandfonline.com/doi/abs/10.1080/01621459.1949.10483310},
 	doi = {10.1080/01621459.1949.10483310},
-	abstract = {We shall present here the motivation and a general description of a method dealing with a class of problems in mathematical physics. The method is, essentially, a statistical approach to the study of differential equations, or more generally, of integro-differential equations that occur in various branches of the natural sciences.},
 	number = {247},
 	urldate = {2018-07-26},
 	journal = {Journal of the American Statistical Association},
@@ -15,4 +14,35 @@
 	pmid = {18139350},
 	pages = {335--341},
 	file = {Snapshot:/home/thea/.Zotero/storage/MXEH8KBP/01621459.1949.html:text/html},
+}
+
+
+@unpublished{van_den_ende_creating_2021,
+	title = {Creating a {Diamond} {Open} {Access} community journal for {Seismology} and {Earthquake} {Science}},
+	url = {http://eartharxiv.org/repository/view/2557/},
+	author = {van den Ende, Martijn and Bruhat, Lucile and Funning, Gareth and Gabriel, Alice-Agnes and Hicks, Stephen and Jolivet, Romain and Lecocq, Thomas and Rowe, Christie},
+	month = jul,
+	year = {2021},
+	doi = {10.31223/X5304V},
+        type = {EarthArXiv preprint}
+}
+
+@misc{rf_software,
+    title = {trichter/rf: v1.1.1},
+    author = {Eulenfeld, Tom and Mark, Hannah and Katz, Daniel S. and Uieda, Leonardo and Lecocq, Thomas and Megies, Tobias},
+    doi = {10.5281/zenodo.4455036},
+    type = {software},
+    year = {2025},
+}
+
+
+@techreport{mueller_documentation_2003,
+	type = {Open-{File} {Report}},
+	title = {Documentation for 2003 {USGS} {Seismic} {Hazard} {Maps} for {Puerto} {Rico} and the {U}.{S}. {Virgin} {Islands}},
+	url = {https://pubsdata.usgs.gov/pubs/of/2003/ofr-03-379/ofr-03-379.html},
+	language = {en},
+	number = {03-379},
+	institution = {USGS},
+	author = {Mueller, C.S. and Frankel, A.D. and Petersen, M.D. and Leyendecker, E.V.},
+	year = {2003},
 }

--- a/publication_latex/seismica_template.tex
+++ b/publication_latex/seismica_template.tex
@@ -96,7 +96,7 @@ Replace text
 	
 	\section{Introduction}
 	
-	Cite with \citep{metropolis_monte_1949} or \citet{metropolis_monte_1949}
+	Cite with \citep{metropolis_monte_1949} or \citet{metropolis_monte_1949}. \citet{van_den_ende_creating_2021} is an example of a preprint citation that can be adapted for other unpublished work. \citet{rf_software} is an example of a software citation that can be adapted for other code, datasets, seismic networks, etc. \citet{mueller_documentation_2003} is an example of a report citation, which can be adapted for technical and other reports.
 	
 	To refer to a figure, use Fig.~\ref{fig:2} or Figs~\ref{fig:1}, \ref{fig:2} (Tab. and Tabs).
 	

--- a/submission_latex/abbrvnat_seismica_upcasetitle.bst
+++ b/submission_latex/abbrvnat_seismica_upcasetitle.bst
@@ -1,5 +1,7 @@
-%% File: `abbrvnat.bst' last updated - 2023-07-15
+%% File: `abbrvnat.bst' last updated - 2025-04-03
 %% A modification of `abbrv.bst' for use with natbib package
+%%
+%% modified for Seismica
 %%
 %% Copyright 1993-2007 Patrick W Daly
 %% Max-Planck-Institut f\"ur Sonnensystemforschung
@@ -76,7 +78,7 @@ ENTRY
   {}
   { label extra.label sort.label short.list }
 
-INTEGERS { output.state before.all mid.sentence after.sentence after.block }
+INTEGERS { output.state before.all mid.sentence mid.string after.sentence after.block }
 
 FUNCTION {init.state.consts}
 { #0 'before.all :=
@@ -98,7 +100,11 @@ FUNCTION {output.nonnull}
         }
         { output.state before.all =
             'write$
-            { add.period$ " " * write$ }
+            { output.state mid.string =
+                { " " * write$ }
+                { add.period$ " " * write$ }
+            if$
+            }
           if$
         }
       if$
@@ -281,10 +287,82 @@ FUNCTION {format.url}
   if$
 }
 
+FUNCTION { strip.doi }
+{ % Borrowed from Association for Computing Machinery typesetting materials
+  %
+  % Strip any Web address prefix to recover the bare DOI, leaving the
+  % result on the output stack, as recommended by CrossRef DOI
+  % documentation.
+  % For example, reduce "http://doi.acm.org/10.1145/1534530.1534545" to
+  % "10.1145/1534530.1534545".  A suitable URL is later typeset and
+  % displayed as the LAST item in the reference list entry.  Publisher Web
+  % sites wrap this with a suitable link to a real URL to resolve the DOI,
+  % and the master https://doi.org/ address is preferred, since publisher-
+  % specific URLs can disappear in response to economic events.  All
+  % journals are encouraged by the DOI authorities to use that typeset
+  % format and link procedures for uniformity across all publications that
+  % include DOIs in reference lists.
+  % The numeric prefix is guaranteed to start with "10.", so we use
+  % that as a test.
+  % 2017-02-04 Added stripping of https:// (Boris Veytsman)
+  doi #1 #3 substring$ "10." =
+    { doi }
+    {
+      doi 't :=  % get modifiable copy of DOI
+
+      % Change https:// to http:// to strip both prefixes (BV)
+
+      t #1 #8 substring$ "https://" =
+        { "http://"  t #9 t text.length$ #8 - substring$ * 't := }
+        { }
+      if$
+
+      t #1 #7 substring$ "http://" =
+        {
+            t #8 t text.length$ #7 - substring$ 't :=
+
+            "INTERNAL STYLE-FILE ERROR" 's :=
+
+            % search for next "/" and assign its suffix to s
+
+            { t text.length$ }
+            {
+              t #1 #1 substring$ "/" =
+                {
+                  % save rest of string as true DOI (should be 10.xxxx/yyyy)
+                  t #2 t text.length$ #1 - substring$ 's :=
+                  "" 't :=    % empty string t terminates the loop
+                }
+                {
+                  % discard first character and continue loop: t <= substring(t,2,last)
+                  t #2 t text.length$ #1 - substring$ 't :=
+                }
+              if$
+            }
+            while$
+
+            % check for valid DOI (should be 10.xxxx/yyyy)
+            s #1 #3 substring$ "10." =
+              { }
+              { "unrecognized DOI substring " s * " in DOI value [" * doi * "]" * warning$ }
+            if$
+
+            s   % push the stripped DOI on the output stack
+
+        }
+        {
+          "unrecognized DOI value [" doi * "]" * warning$
+          doi   % push the unrecognized original DOI on the output stack
+        }
+      if$
+    }
+  if$
+}
+
 FUNCTION {format.doi}
 { doi empty$
     { "" }
-    { new.block "\doi{" doi * "}" * }
+    { new.block "\doi{" strip.doi * "}" * }
   if$
 }
 
@@ -294,17 +372,15 @@ FUNCTION {format.doiurl}
         { "" }
         {new.block "\url{" url * "}" * }
         if$}
-    { new.block "\doi{" doi * "}" * }
+    { new.block "\doi{" strip.doi * "}" * }
     if$
 }
 
 FUNCTION {format.title}
-{ 
-%title empty$
-%    { "" }
-%    { title "t" change.case$ }
-%  if$
-title
+{ title empty$
+    { "" }
+    { title }
+if$
 }
 
 FUNCTION {format.full.names}
@@ -624,6 +700,14 @@ FUNCTION {format.thesis.type}
   if$
 }
 
+FUNCTION {format.misc.type}
+{ type field.or.null
+  duplicate$ empty$ 'skip$
+    { mid.string 'output.state :=
+    " [" swap$  * "]" *  }
+  if$
+}
+
 FUNCTION {format.tr.number}
 { type empty$
     { "Technical Report" }
@@ -635,10 +719,9 @@ FUNCTION {format.tr.number}
   if$
 }
 
-
-FUNCTION {format.ofr.number}
+FUNCTION {format.preprint.number}
 { type empty$
-    { "Open-file Report" }
+    { "Unpublished" }
     'type
   if$
   number empty$
@@ -950,6 +1033,7 @@ FUNCTION {misc}
   author format.key output
   title howpublished new.block.checkb
   format.title output
+  format.misc.type output
   howpublished new.block.checka
   howpublished output
   format.date output
@@ -1003,21 +1087,6 @@ FUNCTION {proceedings}
   fin.entry
 }
 
-FUNCTION {software}
-{ output.bibitem
-  format.authors "author" output.check
-  author format.key output
-  new.block
-  format.title "title" output.check
-  new.block
-  %format.url output
-  %format.doi output
-  format.doiurl output
-  new.block
-  note output
-  fin.entry
-}
-
 FUNCTION {techreport}
 { output.bibitem
   format.authors "author" output.check
@@ -1036,25 +1105,6 @@ FUNCTION {techreport}
   fin.entry
 }
 
-
-FUNCTION {openfilereport}
-{ output.bibitem
-  format.authors "author" output.check
-  author format.key output
-  new.block
-  format.title "title" output.check
-  new.block
-  format.ofr.number output.nonnull
-  institution "institution" output.check
-  address output
-  format.date "year" output.check
-  %format.url output
-  format.doiurl output
-  new.block
-  note output
-  fin.entry
-}
-
 FUNCTION {unpublished}
 { output.bibitem
   format.authors "author" output.check
@@ -1062,9 +1112,11 @@ FUNCTION {unpublished}
   new.block
   format.title "title" output.check
   new.block
+  format.preprint.number output.nonnull
   note "note" output.check
   format.date output
-  format.url output
+  new.block
+  format.doiurl output
   fin.entry
 }
 

--- a/submission_latex/mybibfile.bib
+++ b/submission_latex/mybibfile.bib
@@ -5,7 +5,6 @@
 	issn = {0162-1459},
 	url = {https://www.tandfonline.com/doi/abs/10.1080/01621459.1949.10483310},
 	doi = {10.1080/01621459.1949.10483310},
-	abstract = {We shall present here the motivation and a general description of a method dealing with a class of problems in mathematical physics. The method is, essentially, a statistical approach to the study of differential equations, or more generally, of integro-differential equations that occur in various branches of the natural sciences.},
 	number = {247},
 	urldate = {2018-07-26},
 	journal = {Journal of the American Statistical Association},
@@ -14,4 +13,37 @@
 	year = {1949},
 	pmid = {18139350},
 	pages = {335--341},
+	file = {Snapshot:/home/thea/.Zotero/storage/MXEH8KBP/01621459.1949.html:text/html},
 }
+
+
+@unpublished{van_den_ende_creating_2021,
+	title = {Creating a {Diamond} {Open} {Access} community journal for {Seismology} and {Earthquake} {Science}},
+	url = {http://eartharxiv.org/repository/view/2557/},
+	author = {van den Ende, Martijn and Bruhat, Lucile and Funning, Gareth and Gabriel, Alice-Agnes and Hicks, Stephen and Jolivet, Romain and Lecocq, Thomas and Rowe, Christie},
+	month = jul,
+	year = {2021},
+	doi = {10.31223/X5304V},
+        type = {EarthArXiv preprint}
+}
+
+@misc{rf_software,
+    title = {trichter/rf: v1.1.1},
+    author = {Eulenfeld, Tom and Mark, Hannah and Katz, Daniel S. and Uieda, Leonardo and Lecocq, Thomas and Megies, Tobias},
+    doi = {10.5281/zenodo.4455036},
+    type = {software},
+    year = {2025},
+}
+
+
+@techreport{mueller_documentation_2003,
+	type = {Open-{File} {Report}},
+	title = {Documentation for 2003 {USGS} {Seismic} {Hazard} {Maps} for {Puerto} {Rico} and the {U}.{S}. {Virgin} {Islands}},
+	url = {https://pubsdata.usgs.gov/pubs/of/2003/ofr-03-379/ofr-03-379.html},
+	language = {en},
+	number = {03-379},
+	institution = {USGS},
+	author = {Mueller, C.S. and Frankel, A.D. and Petersen, M.D. and Leyendecker, E.V.},
+	year = {2003},
+}
+

--- a/submission_latex/seismica_template.tex
+++ b/submission_latex/seismica_template.tex
@@ -140,7 +140,7 @@
 	Section names are at the discretion of the authors. A simple structure for an article would include an Introduction, Methods and Data, Results, Discussion, and Conclusions, but authors are encouraged to choose a structure that best presents their work.
 	
 	\subsection{Bibliographic citations}
-	In the text of an article, citations may either be in-line, as in the case of citing \citet{metropolis_monte_1949}, or in parentheses \citep[e.g.,][]{metropolis_monte_1949}, as appropriate. All citations in the text must be listed in the references section, and all listed references must be cited at least once in the text. 
+	In the text of an article, citations may either be in-line, as in the case of citing \citet{metropolis_monte_1949}, or in parentheses \citep[e.g.,][]{metropolis_monte_1949}, as appropriate. All citations in the text must be listed in the references section, and all listed references must be cited at least once in the text. Examples of preprint \citep{van_den_ende_creating_2021}, software \citep{rf_software}, and report \citep{mueller_documentation_2003} citations can be found in the .bib file accompanying this template, and can be adapted for other code, datasets, seismic networks, unpublished works, reports, and more.
 
         There are other ways to format citations in TeX -- for example using \texttt{\textbackslash citeauthor\{\}} and \texttt{\textbackslash citeyear\{\}}. We ask that you stick to \texttt{\textbackslash citep} and \texttt{\textbackslash citet} as shown in the preceding paragraph.
 	


### PR DESCRIPTION
I made some changes to the abbrvnat bst file (upcasetitle only):

- use "type" field in misc entries to mark software or data (and get rid of separate software entry type)
- use "type" field in techreport entries better, so we don't need a separate entry type for open file reports anymore
- update unpublished entries so they're easier to use for preprints (esp arXiv which has their own numbering system)
- add a function that strips excess URL from DOI fields if it's present

There are some new example citations in the templates as well to show usage for reports, software, and preprints.